### PR TITLE
Add WakeLock-s to ExecuteRadioProfilePrefsService and ExecuteVolumeProfilePrefsService

### DIFF
--- a/phoneProfilesPlus/src/main/java/sk/henrichg/phoneprofilesplus/ActivateProfileHelper.java
+++ b/phoneProfilesPlus/src/main/java/sk/henrichg/phoneprofilesplus/ActivateProfileHelper.java
@@ -1278,6 +1278,7 @@ public class ActivateProfileHelper {
         volumeServiceIntent.putExtra(PPApplication.EXTRA_PROFILE_ID, profile._id);
         volumeServiceIntent.putExtra(EXTRA_MERGED_PROFILE, merged);
         volumeServiceIntent.putExtra(EXTRA_FOR_PROFILE_ACTIVATION, true);
+        ExecuteVolumeProfilePrefsService.makeWakeLockBeforeStart(context, volumeServiceIntent);
         context.startService(volumeServiceIntent);
         /*AudioManager audioManager = (AudioManager)context.getSystemService(Context.AUDIO_SERVICE);
         // nahodenie ringer modu - aby sa mohli nastavit hlasitosti
@@ -1307,6 +1308,7 @@ public class ActivateProfileHelper {
         Intent radioServiceIntent = new Intent(context, ExecuteRadioProfilePrefsService.class);
         radioServiceIntent.putExtra(PPApplication.EXTRA_PROFILE_ID, profile._id);
         radioServiceIntent.putExtra(EXTRA_MERGED_PROFILE, merged);
+        ExecuteRadioProfilePrefsService.makeWakeLockBeforeStart(context, radioServiceIntent);
         context.startService(radioServiceIntent);
 
         // nahodenie auto-sync

--- a/phoneProfilesPlus/src/main/java/sk/henrichg/phoneprofilesplus/ExecuteVolumeProfilePrefsService.java
+++ b/phoneProfilesPlus/src/main/java/sk/henrichg/phoneprofilesplus/ExecuteVolumeProfilePrefsService.java
@@ -12,7 +12,7 @@ public class ExecuteVolumeProfilePrefsService extends IntentService
     private static volatile PowerManager.WakeLock wakeLock = null;
 
     public ExecuteVolumeProfilePrefsService() {
-        super("ExecuteRadioProfilePrefsService");
+        super("ExecuteVolumeProfilePrefsService");
     }
     
     public static synchronized void makeWakeLockBeforeStart(Context context, Intent intent) {


### PR DESCRIPTION
This fixes radios (e.g. airplane mode) not being changed on scheduled profile change. 

On my device airplane mode wasn't switched off when scheduled profile change occurred. Instead the airplane mode was switched off a few seconds after I switched on phone screen after the scheduled change should have occurred. Battery optimization was disabled for Phone Profiles Plus. The issue was reproduced several times, after applying this fix the issue wasn't reproducible anymore.