### PR TITLE
Add ticking end time in FastAccessDurationDialog

### DIFF
--- a/phoneProfilesPlus/src/main/java/sk/henrichg/phoneprofilesplus/GlobalGUIRoutines.java
+++ b/phoneProfilesPlus/src/main/java/sk/henrichg/phoneprofilesplus/GlobalGUIRoutines.java
@@ -476,6 +476,10 @@ public class GlobalGUIRoutines {
 
     @SuppressLint("DefaultLocale")
     static String getEndsAtString(int duration) {
+        if(duration == 0) {
+            return "--";
+        }
+
         Calendar ends = Calendar.getInstance();
         ends.add(Calendar.SECOND, duration);
         int hours = ends.get(Calendar.HOUR_OF_DAY);

--- a/phoneProfilesPlus/src/main/java/sk/henrichg/phoneprofilesplus/GlobalGUIRoutines.java
+++ b/phoneProfilesPlus/src/main/java/sk/henrichg/phoneprofilesplus/GlobalGUIRoutines.java
@@ -474,6 +474,16 @@ public class GlobalGUIRoutines {
         return String.format("%02d:%02d:%02d", hours, minutes, seconds);
     }
 
+    @SuppressLint("DefaultLocale")
+    static String getEndsAtString(int duration) {
+        Calendar ends = Calendar.getInstance();
+        ends.add(Calendar.SECOND, duration);
+        int hours = ends.get(Calendar.HOUR_OF_DAY);
+        int minutes = ends.get(Calendar.MINUTE);
+        int seconds = ends.get(Calendar.SECOND);
+        return String.format("%02d:%02d:%02d", hours, minutes, seconds);
+    }
+
     static Point getNavigationBarSize(Context context) {
         Point appUsableSize = getAppUsableScreenSize(context);
         Point realScreenSize = getRealScreenSize(context);

--- a/phoneProfilesPlus/src/main/res/layout-v17/activity_fast_access_duration_dialog.xml
+++ b/phoneProfilesPlus/src/main/res/layout-v17/activity_fast_access_duration_dialog.xml
@@ -24,16 +24,47 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content" >
 
-        <EditText
-            android:id="@+id/duration_pref_dlg_value"
-            android:layout_width="wrap_content"
+        <LinearLayout
+            android:orientation="horizontal"
+            android:layout_gravity="center"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_gravity="center_horizontal"
-            android:layout_marginBottom="10dp"
-            android:gravity="center_horizontal"
-            android:inputType="number"
-            android:digits="0123456789:"
-            android:textSize="20sp" />
+            android:layout_marginStart="12dp"
+            android:layout_marginEnd="12dp" >
+
+            <LinearLayout
+                android:orientation="horizontal"
+                android:layout_gravity="center"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:layout_weight="1" >
+
+                <EditText
+                    android:id="@+id/duration_pref_dlg_value"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:layout_marginBottom="10dp"
+                    android:gravity="center_horizontal"
+                    android:inputType="number"
+                    android:digits="0123456789:"
+                    android:textSize="20sp" />
+
+            </LinearLayout>
+
+
+            <TextView
+                android:id="@+id/duration_pref_dlg_ends"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:layout_gravity="center"
+                android:layout_marginBottom="10dp"
+                android:gravity="center_horizontal"
+                android:textSize="20sp" />
+
+        </LinearLayout>
 
         <!--
         <TextView

--- a/phoneProfilesPlus/src/main/res/layout/activity_fast_access_duration_dialog.xml
+++ b/phoneProfilesPlus/src/main/res/layout/activity_fast_access_duration_dialog.xml
@@ -24,16 +24,47 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content" >
 
-        <EditText
-            android:id="@+id/duration_pref_dlg_value"
-            android:layout_width="wrap_content"
+        <LinearLayout
+            android:orientation="horizontal"
+            android:layout_gravity="center"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_gravity="center_horizontal"
-            android:layout_marginBottom="10dp"
-            android:gravity="center_horizontal"
-            android:inputType="number"
-            android:digits="0123456789:"
-            android:textSize="20sp" />
+            android:layout_marginStart="12dp"
+            android:layout_marginEnd="12dp" >
+
+            <LinearLayout
+                android:orientation="horizontal"
+                android:layout_gravity="center"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:layout_weight="1" >
+
+                <EditText
+                    android:id="@+id/duration_pref_dlg_value"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:layout_marginBottom="10dp"
+                    android:gravity="center_horizontal"
+                    android:inputType="number"
+                    android:digits="0123456789:"
+                    android:textSize="20sp" />
+
+            </LinearLayout>
+
+
+            <TextView
+                android:id="@+id/duration_pref_dlg_ends"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:layout_gravity="center"
+                android:layout_marginBottom="10dp"
+                android:gravity="center_horizontal"
+                android:textSize="20sp" />
+
+        </LinearLayout>
 
         <!--
         <TextView


### PR DESCRIPTION
Display ticking end time when asking for duration during profile activation. 

I guess in many cases when selecting duration during profile activation, it is handy to see till what time the profile would be active. This pull request adds a ticking end time to the profile activation dialog. The size of the dialog stays the same (at least on big screens). 

I guess this would need some testing. I will do some testing on devices available to me. 
Could you please review the code, layout and do some testing as well?