### PR TITLE
fix: trigger outside mobile cell event when connected cell is not any…

### DIFF
--- a/phoneProfilesPlus/src/main/java/sk/henrichg/phoneprofilesplus/EventPreferencesMobileCells.java
+++ b/phoneProfilesPlus/src/main/java/sk/henrichg/phoneprofilesplus/EventPreferencesMobileCells.java
@@ -553,7 +553,7 @@ class EventPreferencesMobileCells extends EventPreferences {
                                                                 }
                                                             }
                                                         } else {
-                                                            eventsHandler.mobileCellPassed = false;
+                                                            eventsHandler.mobileCellPassed = _whenOutside;
                                                         }
                                                         cellIsValid = true;
                                                     }
@@ -592,7 +592,7 @@ class EventPreferencesMobileCells extends EventPreferences {
                                                                 }
                                                             }
                                                         } else {
-                                                            eventsHandler.mobileCellPassed = false;
+                                                            eventsHandler.mobileCellPassed = _whenOutside;
                                                         }
                                                         cellIsValid = true;
                                                     }
@@ -629,7 +629,7 @@ class EventPreferencesMobileCells extends EventPreferences {
                                                             }
                                                         }
                                                     } else {
-                                                        eventsHandler.mobileCellPassed = false;
+                                                        eventsHandler.mobileCellPassed = _whenOutside;
                                                     }
                                                     cellIsValid = true;
                                                 }


### PR DESCRIPTION
… list

When current connected mobile cell is not on any defined list, "Mobile cell sensor" with enabled "start when outside..." stay inactive. Adding this cell to any other list make this sensor work ok. In this form this feature has very limited usability.

Problem is result of getting list of cells filtered by current connected cell (db.addMobileCellsToList(_cellsList, registeredCell)) and do next checks only when this list is not empty. If we are connected to unknown cell (list is empty), no more check are performed even when we check "outside".

Now, when cells list is empty, default result depend on _whenOutside, so empty list and "outside" enabled trigger event. When "outside" is false, there is no change in behaviour.